### PR TITLE
Allow flexibility in usage for readPDF.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
     Or you can optionally run 
 
-    - ./readPDF \<input PDF name\> \<Output MP3 name\>
+    - ./readPDF <input PDF name> <Output MP3 name>
 
     If the 2 arduments aren't specified, then it will prompt you for the names of both files requiring additional user input
     

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
     - poppler-utils
     - gtts
 # How to run
-    - execute the readPDF.sh script
-    - put in the name of the pdf file you want to read
-    - put in the name of the mp3 file you want to save
+    - execute the readPDF.sh script (To make executable, run chmod +x readPDF.sh)
+    - put in the name of the PDF file you want to read
+    - put in the name of the MP3 file you want to save
+
+    Or you can optionally run 
+
+    - ./readPDF \<input PDF name\> \<Output MP3 name\>
+
+    If the 2 arduments aren't specified, then it will prompt you for the names of both files requiring additional user input
     

--- a/read.py
+++ b/read.py
@@ -9,7 +9,7 @@ def main():
     try:
         f = open(filename, "r")
     except FileNotFoundError:
-        print("File not found")
+        print("File '%s' not found" %filename)
         sys.exit(1)
     text = f.read()
     # print(text)

--- a/readPDF.sh
+++ b/readPDF.sh
@@ -1,13 +1,14 @@
-if [[ $# -ne 2 ]]
+if [[ $# -ne 2 ]] 
+#if the number of arguments is 2, don't prompt the user for the file names
 then
 	read -p "What is the name of the PDF file? " fileName
 	read -p "What is the name of the output file? " outputName
 else
-	filename=$1
-	outputName=$2
+	fileName=${1}
+	outputName=${2}
 fi
 
-pdftotext -q -raw $fileName $outputName
+pdftotext -q -raw ${fileName} ${outputName}
 
-python3 read.py $outputName
-rm $outputName
+python3 read.py ${outputName}
+rm -f ${outputName}

--- a/readPDF.sh
+++ b/readPDF.sh
@@ -1,7 +1,12 @@
-echo "What is the name of the PDF file?"
-read fileName
-echo "What is the name of the output file?"
-read outputName
+if [[ $# -ne 2 ]]
+then
+	read -p "What is the name of the PDF file? " fileName
+	read -p "What is the name of the output file? " outputName
+else
+	filename=$1
+	outputName=$2
+fi
+
 pdftotext -q -raw $fileName $outputName
 
 python3 read.py $outputName


### PR DESCRIPTION
This will let the user assign the input and output filenames right at execution, so it can save a little time and save some time for larger files with the shells built-in tab completion for files